### PR TITLE
support for force approval_prompt

### DIFF
--- a/lib/passport-strava/strategy.js
+++ b/lib/passport-strava/strategy.js
@@ -98,6 +98,16 @@ Strategy.prototype.userProfile = function(accessToken, done) {
   });
 }
 
+/**
+ * override authorizationParams to support approval_prompt
+ */
+Strategy.prototype.authorizationParams = function(options) {
+  var params = {};
+  var approval_prompt = options.approval_prompt;
+  if (approval_prompt) { params.approval_prompt = approval_prompt; }
+  return params;
+}
+
 
 /**
  * Expose `Strategy`.


### PR DESCRIPTION
Strava supports an "approval_prompt" param in the oauth2 request. Added support to Strategy overriding authenticationParams per the api doc in passport-oauth2. 

http://strava.github.io/api/v3/oauth/
https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js
